### PR TITLE
Add Area loot condition

### DIFF
--- a/src/main/java/dev/doublekekse/area_tools/AreaTools.java
+++ b/src/main/java/dev/doublekekse/area_tools/AreaTools.java
@@ -1,6 +1,7 @@
 package dev.doublekekse.area_tools;
 
 import dev.doublekekse.area_tools.command.AreaToolsCommand;
+import dev.doublekekse.area_tools.loot.condition.LootItemEntityAreaCondition;
 import dev.doublekekse.area_tools.registry.AreaComponents;
 import dev.doublekekse.area_tools.registry.AreaItemComponents;
 import dev.doublekekse.area_tools.registry.AreaItems;
@@ -31,6 +32,8 @@ public class AreaTools implements ModInitializer {
                 AreaToolsCommand.register(dispatcher);
             }
         );
+
+        LootItemEntityAreaCondition.register();
     }
 
     public static void runCommands(MinecraftServer server, Player player, List<String> commands) {

--- a/src/main/java/dev/doublekekse/area_tools/loot/condition/LootItemEntityAreaCondition.java
+++ b/src/main/java/dev/doublekekse/area_tools/loot/condition/LootItemEntityAreaCondition.java
@@ -1,0 +1,40 @@
+package dev.doublekekse.area_tools.loot.condition;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.doublekekse.area_lib.AreaLib;
+import dev.doublekekse.area_tools.AreaTools;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import org.jetbrains.annotations.NotNull;
+
+public record LootItemEntityAreaCondition(
+        ResourceLocation areaId,
+        LootContext.EntityTarget entityTarget
+) implements LootItemCondition {
+    public static MapCodec<LootItemEntityAreaCondition> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            ResourceLocation.CODEC.fieldOf("area_id").forGetter(LootItemEntityAreaCondition::areaId),
+            LootContext.EntityTarget.CODEC.fieldOf("entity").forGetter(LootItemEntityAreaCondition::entityTarget)
+    ).apply(instance, LootItemEntityAreaCondition::new));
+
+    @Override
+    public @NotNull LootItemConditionType getType() {
+        return TYPE;
+    }
+
+    @Override
+    public boolean test(LootContext lootContext) {
+        var area = AreaLib.getServerArea(lootContext.getLevel().getServer(), areaId);
+        return area != null && area.contains(lootContext.getParam(this.entityTarget.getParam()));
+    }
+
+    public static LootItemConditionType TYPE = Registry.register(BuiltInRegistries.LOOT_CONDITION_TYPE, AreaTools.id("area"), new LootItemConditionType(CODEC));
+
+    public static void register() {
+
+    }
+}


### PR DESCRIPTION
Example loot table:

```json
{
  "type": "minecraft:entity",
  "pools": [
    {
      "rolls": 1,
      "entries": [
        {
          "type": "minecraft:item",
          "name": "minecraft:trial_key"
        }
      ],
      "conditions": [
        {
          "condition": "area_tools:area",
          "entity": "this",
          "area_id": "area_tools:test"
        }
      ]
    }
  ]
}
```

I don't know if you want the `LootItemConditionType` to be located in the class or in some initializer class, let me know any changes wanted
