### PR TITLE
fix: Implement equality checks to allow items to stack.

### DIFF
--- a/src/main/java/dev/doublekekse/area_tools/component/item/AreaComponent.java
+++ b/src/main/java/dev/doublekekse/area_tools/component/item/AreaComponent.java
@@ -59,4 +59,21 @@ public final class AreaComponent {
             consumer.accept(Component.translatable("item.area_tools.area_component." + type).withStyle(ChatFormatting.GRAY));
         }
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof AreaComponent otherComponent)) {
+            return false;
+        }
+
+        return areaId.equals(otherComponent.areaId);
+    }
+
+    @Override
+    public int hashCode() {
+        return areaId.hashCode();
+    }
 }


### PR DESCRIPTION
`area_tools:dissolve` prevents items with the same component from stacking with one another, this fixes this incorrect behavior.